### PR TITLE
Benchmark test

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,5 +41,6 @@ benchmark:
     mem_limit: 4g
     restart: always
     links:
+    - consul
     - couchbase
     command: benchmark.bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ couchbase:
     image: misterbisson/triton-couchbase
     links:
     - consul
-    mem_limit: 4096m
+    mem_limit: 222g
     ports:
     - 8091
     - 8092

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,9 +37,9 @@ couchbase:
 # Benchmarks, for fun and sparkles
 #
 benchmark:
-    image: misterbisson/couchbase-cloud-benchmark
-    command: start.bash
-    links:
-    - consul
-    mem_limit: 1024m
+    image: 0x74696d/pillowfight
+    mem_limit: 4g
     restart: always
+    links:
+    - couchbase
+    command: benchmark.bash

--- a/start.bash
+++ b/start.bash
@@ -49,3 +49,6 @@ docker-compose --project-name=$PREFIX scale couchbase=3
 echo
 echo "Go ahead, try a lucky 7 node cluster:"
 echo "docker-compose --project-name="$PREFIX" scale couchbase=7"
+echo
+echo "Or scale up test clients:"
+echo "docker-compose --project-name="$PREFIX" scale benchmark=7"

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,0 +1,10 @@
+# Container for running cbc-pillowfight Couchbase stress test
+FROM 		debian:wheezy
+
+# set up couchbase apt sources
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CD406E62 D9223EDA
+RUN echo "deb http://packages.couchbase.com/ubuntu wheezy wheezy/main" > /etc/apt/sources.list.d/couchbase.list
+
+# get cbc-pillowfight
+RUN apt-get update -qq
+RUN apt-get install -y libcouchbase2-bin

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,10 +1,28 @@
 # Container for running cbc-pillowfight Couchbase stress test
-FROM 		debian:wheezy
+FROM 		couchbase/server:enterprise-3.0.3
 
 # set up couchbase apt sources
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CD406E62 D9223EDA
 RUN echo "deb http://packages.couchbase.com/ubuntu wheezy wheezy/main" > /etc/apt/sources.list.d/couchbase.list
-
-# get cbc-pillowfight
 RUN apt-get update -qq
+
+# install cbc-pillowfight
 RUN apt-get install -y libcouchbase2-bin
+
+# installed Node.js, similar to https://github.com/joyent/docker-node/blob/428d5e69763aad1f2d8f17c883112850535e8290/0.12/Dockerfile
+RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 7937DFD2AB06298B2293C3187D33FF9D0246406D 114F43EE0176B71C7BC219DD50A3051F888C628D
+
+ENV NODE_VERSION 0.12.4
+ENV NPM_VERSION 2.10.1
+
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
+	&& curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+	&& gpg --verify SHASUMS256.txt.asc \
+	&& grep " node-v$NODE_VERSION-linux-x64.tar.gz\$" SHASUMS256.txt.asc | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-x64.tar.gz" SHASUMS256.txt.asc \
+	&& npm install -g npm@"$NPM_VERSION" \
+	&& npm cache clear
+
+RUN npm install -g json
+ADD benchmark.bash /bin/benchmark.bash

--- a/test/benchmark.bash
+++ b/test/benchmark.bash
@@ -11,14 +11,15 @@ HOSTSTRING=$(IFS="," ; echo "${HOSTS[*]}")
 
 echo Running benchmark vs $HOSTSTRING...
 
-docker run -m 1G 0x74696d/pillowfight cbc-pillowfight \
+docker run -d -m 8G 0x74696d/pillowfight cbc-pillowfight \
        --spec couchbase://$HOSTSTRING/benchmark \
-       --min-size=200 \
-       --max-size=200 \
-       --num-threads=10 \
-       --num-items=1000 \
-       --batch-size=500 \
+       --min-size=800 \
+       --max-size=800 \
+       --num-threads=64 \
+       --num-items=1000000 \
+       --batch-size=5000 \
        --num-cycles=10000 \
        --set-pct=10 \
-       --rate-limit=500000 \
-       --timings
+       --rate-limit=1000000 \
+       --timings \
+       --verbose

--- a/test/benchmark.bash
+++ b/test/benchmark.bash
@@ -11,11 +11,11 @@ HOSTSTRING=$(IFS="," ; echo "${HOSTS[*]}")
 
 echo Running benchmark vs $HOSTSTRING...
 
-docker run -d -m 8G 0x74696d/pillowfight cbc-pillowfight \
+docker run -d -m 4G 0x74696d/pillowfight cbc-pillowfight \
        --spec couchbase://$HOSTSTRING/benchmark \
        --min-size=800 \
        --max-size=800 \
-       --num-threads=64 \
+       --num-threads=32 \
        --num-items=1000000 \
        --batch-size=5000 \
        --num-cycles=10000 \

--- a/test/benchmark.bash
+++ b/test/benchmark.bash
@@ -1,25 +1,50 @@
 #!/bin/bash
 
-# create a list of our couchbase nodes
+# create a list of our linked couchbase nodes
 echo Querying for couchbase nodes...
 HOSTS=()
-for container in `docker ps | grep ccic_couchbase | awk -F' +' '{print $NF}'`
+for ip in `env | grep "CCIC_COUCHBASE_.*_PORT_8092_TCP_ADDR" | cut -d'=' -f2`
 do
-    HOSTS+=(`docker inspect $container | json -a NetworkSettings.IPAddress`)
+    HOSTS+=("$ip")
 done
 HOSTSTRING=$(IFS="," ; echo "${HOSTS[*]}")
+NUM_HOSTS=${#HOSTS[@]}
+
+echo Polling couchbase nodes...
+CLUSTERFOUND=0
+while [ "$CLUSTERFOUND" -lt ${NUM_HOSTS} ]; do
+    echo -n '.'
+    sleep 19
+
+    CLUSTERFOUND=$(curl -sL http://consul:8500/v1/catalog/service/couchbase | json -aH ServiceAddress | wc -l)
+done
+sleep 3
+
+CLUSTERFOUND=0
+while [ $CLUSTERFOUND != 1 ]; do
+    echo -n '.'
+
+    CLUSTERIP=$(curl -sL http://consul:8500/v1/catalog/service/couchbase | json -aH ServiceAddress | head -1)
+    if [ -n "$CLUSTERIP" ]
+    then
+        let CLUSTERFOUND=1
+    else
+        sleep 3
+    fi
+done
+sleep 3
+
 
 echo Running benchmark vs $HOSTSTRING...
-
-docker run -d -m 4G 0x74696d/pillowfight cbc-pillowfight \
-       --spec couchbase://$HOSTSTRING/benchmark \
-       --min-size=800 \
-       --max-size=800 \
-       --num-threads=32 \
-       --num-items=1000000 \
-       --batch-size=5000 \
-       --num-cycles=10000 \
-       --set-pct=10 \
-       --rate-limit=1000000 \
-       --timings \
-       --verbose
+cbc-pillowfight \
+    --spec couchbase://$HOSTSTRING/benchmark \
+    --min-size=800 \
+    --max-size=800 \
+    --num-threads=32 \
+    --num-items=1000000 \
+    --batch-size=5000 \
+    --num-cycles=-1 \
+    --set-pct=10 \
+    --rate-limit=1000000 \
+    --timings \
+    --verbose

--- a/test/benchmark.bash
+++ b/test/benchmark.bash
@@ -43,7 +43,7 @@ cbc-pillowfight \
     --num-threads=32 \
     --num-items=1000000 \
     --batch-size=5000 \
-    --num-cycles=-1 \
+    --num-cycles=10000 \
     --set-pct=10 \
     --rate-limit=1000000 \
     --timings \

--- a/test/benchmark.bash
+++ b/test/benchmark.bash
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# create a list of our couchbase nodes
+echo Querying for couchbase nodes...
+HOSTS=()
+for container in `docker ps | grep ccic_couchbase | awk -F' +' '{print $NF}'`
+do
+    HOSTS+=(`docker inspect $container | json -a NetworkSettings.IPAddress`)
+done
+HOSTSTRING=$(IFS="," ; echo "${HOSTS[*]}")
+
+echo Running benchmark vs $HOSTSTRING...
+
+docker run -m 1G 0x74696d/pillowfight cbc-pillowfight \
+       --spec couchbase://$HOSTSTRING/benchmark \
+       --min-size=200 \
+       --max-size=200 \
+       --num-threads=10 \
+       --num-items=1000 \
+       --batch-size=500 \
+       --num-cycles=10000 \
+       --set-pct=10 \
+       --rate-limit=500000 \
+       --timings


### PR DESCRIPTION
@misterbisson this is still work-in-progress. A build of this container can be pulled down from DockerHub via `docker pull 0x74696d/pillowfight`.

Once I'm done in a bit here, this PR will also include a script to run the test that'll go as follows:
- use `docker ps` and `docker inspect` to get the list of IPs for active Couchbase nodes
- run this container against those IPs
