### PR TITLE
Build both perf-external and durability-tokens branchs of libcouchbase

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,4 @@
-#
 # Using a single Consul host is _highly_ discouraged, but yolo
-#
 consul:
     image: progrium/consul:latest
     command: -server -bootstrap-expect 1 -ui-dir /ui
@@ -48,54 +46,9 @@ couchbase3:
     - 18092
     restart: always
 
-benchmark_test:
-    image: 0x74696d/cbc-benchmark
-    mem_limit: 512m
-    volumes:
-    - ./test:/src
-    links:
-    - consul
-    environment:
-    - ITEMS=1000
-    command: /bin/bash
-    restart: never
-
-# run the client to create indexes. this client will exit when complete
-benchmark_index:
-    image: 0x74696d/cbc-benchmark
-    mem_limit: 256m
-    links:
-    - consul
-    environment:
-    - ITEMS=1000000
-    command: /bin/cbc-benchmark index
-    restart: never
-
-# run the client to load test data. this client will exit when complete
-benchmark_load:
-    image: 0x74696d/cbc-benchmark
-    mem_limit: 1g
-    links:
-    - consul
-    environment:
-    - ITEMS=1000000
-    command: /bin/cbc-benchmark load
-    restart: never
-
-# run the client to benchmark n1ql queries
-benchmark_n1ql:
-    image: 0x74696d/cbc-benchmark
-    mem_limit: 64g
-    links:
-    - consul
-    environment:
-    - ITEMS=1000000
-    - THREADS=10
-    command: /bin/cbc-benchmark n1qlTest
-
-# run the client to benchmark via pillowfight
-benchmark_pillowfight:
-    image: 0x74696d/cbc-benchmark
+# Run the pillowfight client built from the durablity_tokens branch
+pillowfight_durable:
+    image: 0x74696d/cbc-benchmark-durable
     mem_limit: 64g
     links:
     - consul
@@ -105,13 +58,14 @@ benchmark_pillowfight:
     - TIMEOUT=10000000
     command: /bin/cbc-benchmark pillowfight
 
-# run the client to benchmark view queries
-benchmark_views:
-    image: 0x74696d/cbc-benchmark
+# Run the current pillowfight client
+pillowfight_current:
+    image: 0x74696d/cbc-benchmark-perf
     mem_limit: 64g
     links:
     - consul
     environment:
-    - ITEMS=1000000
-    - THREADS=10
-    command: /bin/cbc-benchmark view
+    - ITEMS=93750000
+    - THREADS=20
+    - TIMEOUT=10000000
+    command: /bin/cbc-benchmark pillowfight

--- a/test/Dockerfile-builder
+++ b/test/Dockerfile-builder
@@ -11,7 +11,16 @@ RUN curl -O http://www.cmake.org/files/v3.3/cmake-3.3.1-Linux-x86_64.tar.gz && \
     mv cmake-3.3.1-Linux-x86_64/bin/* /usr/bin && \
     mv cmake-3.3.1-Linux-x86_64/share/cmake-3.3 /usr/share
 
-RUN git clone https://github.com/dhaikney/libcouchbase.git -b durability_tokens
+# build the durability_tokens branch from the published Google benchmark
+RUN mkdir -p /libcouchbase/durability && \
+    cd /libcouchbase/durability && \
+    git clone https://github.com/dhaikney/libcouchbase.git -b durability_tokens && \
+    cd libcouchbase && mkdir build && cd build && \
+    ../cmake/configure && make && ctest
 
-RUN mkdir -p libcouchbase/build
-RUN cd libcouchbase/build && ../cmake/configure && make && ctest
+# build the perf-external branch from Couchbase
+RUN mkdir -p /libcouchbase/perf/build && \
+    cd /libcouchbase/perf && \
+    git clone git://github.com/mnunberg/libcouchbase.git -b perf-external && \
+    cd libcouchbase && mkdir build && cd build && \
+    ../cmake/configure && make && ctest

--- a/test/Dockerfile-durable
+++ b/test/Dockerfile-durable
@@ -8,6 +8,6 @@ RUN npm install -g json
 ADD cbc-benchmark /bin/cbc-benchmark
 
 # add the binary and lib we got from our builder container
-ADD build/cbc-pillowfight /bin
-ADD build/libcouchbase.so.2.0.22 /lib/x86_64-linux-gnu
+ADD build/durability/cbc-pillowfight /bin
+ADD build/durability/libcouchbase.so.2.0.22 /lib/x86_64-linux-gnu
 RUN ln -s /lib/x86_64-linux-gnu/libcouchbase.so.2.0.22 /lib/x86_64-linux-gnu/libcouchbase.so.2

--- a/test/Dockerfile-perf
+++ b/test/Dockerfile-perf
@@ -1,0 +1,13 @@
+# Container for running Couchbase benchmarks
+FROM node:slim
+
+# for parsing JSON output from Consul
+RUN npm install -g json
+
+# add the script we need to run
+ADD cbc-benchmark /bin/cbc-benchmark
+
+# add the binary and lib we got from our builder container
+ADD build/perf/cbc-pillowfight /bin
+ADD build/perf/libcouchbase.so.2.0.28 /lib/x86_64-linux-gnu
+RUN ln -s /lib/x86_64-linux-gnu/libcouchbase.so.2.0.28 /lib/x86_64-linux-gnu/libcouchbase.so.2

--- a/test/makefile
+++ b/test/makefile
@@ -5,7 +5,7 @@ SHELL := /bin/bash
 
 clean:
 	rm -f .build-builder
-	rm -rf build/
+	rm -rf build/perf build/durability
 
 # builds the build container, which contains everything we need
 # to build and test cbc-pillowfight, but that we don't want to ship
@@ -14,14 +14,25 @@ clean:
 	docker build -t="cbc-benchmark-builder" -f=Dockerfile-builder .
 	@touch .build-builder
 
-# grabs the binary and shared lib we need from the builder image
-# and drops them into the much leaner production deployment image
-build: .build-builder
-	mkdir -p build
-	docker cp $(shell docker create cbc-benchmark-builder):/libcouchbase/build/lib/libcouchbase.so.2.0.22 - > build/libcouchbase.so.2.0.22
-	docker cp $(shell docker create cbc-benchmark-builder):/libcouchbase/build/bin/cbc-pillowfight - > build/cbc-pillowfight
-	docker build -t="0x74696d/cbc-benchmark" -f=Dockerfile .
+build: build/perf build/durability
 
-# push our image to the public registry
+# Copy out the libcouchbase perf-external build to a local directory
+# and ADD it during a Docker build
+build/perf: .build-builder
+	mkdir -p build/perf
+	docker cp $(shell docker create cbc-benchmark-builder):/libcouchbase/perf/libcouchbase/build/lib/libcouchbase.so.2.0.28 - > build/perf/libcouchbase.so.2.0.28
+	docker cp $(shell docker create cbc-benchmark-builder):/libcouchbase/perf/libcouchbase/build/bin/cbc-pillowfight - > build/perf/cbc-pillowfight
+	docker build -t="0x74696d/cbc-benchmark-perf" -f=Dockerfile-perf .
+
+# Copy out the libcouchbase durability build to a local directory
+# and ADD it during a Docker build
+build/durability: .build-builder
+	mkdir -p build/durability
+	docker cp $(shell docker create cbc-benchmark-builder):/libcouchbase/durability/libcouchbase/build/lib/libcouchbase.so.2.0.22 - > build/durability/libcouchbase.so.2.0.22
+	docker cp $(shell docker create cbc-benchmark-builder):/libcouchbase/durability/libcouchbase/build/bin/cbc-pillowfight - > build/durability/cbc-pillowfight
+	docker build -t="0x74696d/cbc-benchmark-durable" -f=Dockerfile-durable .
+
+# push our images to the public registry
 ship: build
-	docker push 0x74696d/cbc-benchmark
+	docker push 0x74696d/cbc-benchmark-durable
+	docker push 0x74696d/cbc-benchmark-perf


### PR DESCRIPTION
In order to test both variants of libcouchbase/pillowfight, we build
both versions in the builder container and copy them into separate
client containers to ship.

Updates docker-compose.yml to just have the servers and our two
pillowfight test clients (removing n1qlback tests for now).

cc @max123 to review and merge please.
