### PR TITLE
Multiple-provider test rig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 test/.build-builder
 test/build
 test/.godeps
+test/.aws
+test/.gce

--- a/docker-compose-swarm.yml
+++ b/docker-compose-swarm.yml
@@ -1,0 +1,71 @@
+# Using a single Consul host is _highly_ discouraged, but yolo
+consul:
+    image: progrium/consul:latest
+    command: -server -bootstrap-expect 1 -ui-dir /ui
+    ports:
+    - 53
+    - 8300
+    - 8301
+    - 8302
+    - 8400
+    - 8500:8500
+    restart: always
+
+
+# Manually bootstrap the first instance, then...
+# Scale this tier and each additional container/instance will automatically
+# self-configure as a member of the cluster
+couchbase4:
+    image: 0x74696d/triton-couchbase:4.0.0
+    extra_hosts:
+    - consul:${CONSUL_IP}
+    mem_limit: 128g
+    ports:
+    - 8091:8091
+    - 8092:8092
+    - 11207:11207
+    - 11210:11210
+    - 11211:11211
+    - 18091:18091
+    - 18092:18092
+    restart: always
+
+couchbase3:
+    image: misterbisson/triton-couchbase
+    extra_hosts:
+    - consul:${CONSUL_IP}
+    mem_limit: 128g
+    ports:
+    - 8091:8091
+    - 8092:8092
+    - 11207:11207
+    - 11210:11210
+    - 11211:11211
+    - 18091:18091
+    - 18092:18092
+    restart: always
+
+# Run the pillowfight client built from the durablity_tokens branch
+pillowfight_durable:
+    image: 0x74696d/cbc-benchmark-durable
+    mem_limit: 64g
+    extra_hosts:
+    - consul:${CONSUL_IP}
+    environment:
+    - ITEMS=93750000
+    - THREADS=20
+    - TIMEOUT=10000000
+    - EXTRA_ARGS=--tokens=275 --durability
+    command: /bin/cbc-benchmark pillowfight
+
+# Run the current pillowfight client
+pillowfight_perf:
+    image: 0x74696d/cbc-benchmark-perf
+    mem_limit: 64g
+    extra_hosts:
+    - consul:${CONSUL_IP}
+    environment:
+    - ITEMS=93750000
+    - THREADS=20
+    - TIMEOUT=10000000
+    command: /bin/cbc-benchmark pillowfight

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,10 +56,11 @@ pillowfight_durable:
     - ITEMS=93750000
     - THREADS=20
     - TIMEOUT=10000000
+    - EXTRA_ARGS=--tokens=275 --durability
     command: /bin/cbc-benchmark pillowfight
 
 # Run the current pillowfight client
-pillowfight_current:
+pillowfight_perf:
     image: 0x74696d/cbc-benchmark-perf
     mem_limit: 64g
     links:

--- a/test/cbc-benchmark
+++ b/test/cbc-benchmark
@@ -7,6 +7,7 @@ TIMINGS=${TIMINGS:-}
 QUERIES=${QUERIES:-30}
 CYCLES=${CYCLES:-468750000}
 TIMEOUT=${TIMEOUT:-5000000}
+EXTRA_ARGS=${EXTRA_ARGS:-}
 
 usage() {
     cat <<EOF
@@ -135,14 +136,13 @@ pillowfight() {
                          --set-pct=100 \
                          --batch-size=50 \
                          --rate-limit=20000 \
-                         --tokens=275 \
                          --no-population \
                          --sequential \
-                         --durability \
                          --timeout=${TIMEOUT} \
                          --num-cycles=${CYCLES} \
                          --key-prefix=${h:0:4} \
-                         -U couchbase://${IP}/benchmark
+                         -U couchbase://${IP}/benchmark \
+                         ${EXTRA_ARGS}
     sleep 1
     done
 }

--- a/test/makefile
+++ b/test/makefile
@@ -38,14 +38,14 @@ ship: build
 	docker push 0x74696d/cbc-benchmark-perf
 
 # ------------------------------------------------------
-# docker-machine / swarm tasks for running on AWS/GCE
+# docker-machine / swarm tasks for running on AWS
 # Make sure your AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment
 # variables have been set.
 # You'll also need the awscli installed: https://aws.amazon.com/cli/
 
 aws: .aws/consul .aws/machines
 	@echo All machines ready. To configure your Docker client run:
-	@echo 'eval "$$(docker-machine env --swarm swarm-master)"'
+	@echo 'eval "$$(docker-machine env --swarm swarm-aws-master)"'
 
 # initialize the swarm
 .aws/swarm:
@@ -54,13 +54,13 @@ aws: .aws/consul .aws/machines
 
 # Create the swarm master in your local Virtualbox environment
 .aws/master: .aws/swarm
-	-docker-machine rm swarm-master
+	-docker-machine rm swarm-master-aws
 	docker-machine create \
 		-d virtualbox \
 		--swarm \
 		--swarm-master \
 		--swarm-discovery token://$(shell cat .aws/swarm) \
-		swarm-master
+		swarm-aws-master
 	touch .aws/master
 
 # Set up and get info about the AWS environment.
@@ -101,24 +101,92 @@ aws: .aws/consul .aws/machines
 		--amazonec2-subnet-id $(shell cat .aws/subnet) \
 		--amazonec2-vpc-id $(shell cat .aws/vpc) \
 		--swarm-discovery token://$(shell cat .aws/swarm) \
-		swarm-consul
+		swarm-aws-consul
 	docker-machine ip swarm-consul > .aws/consul
 
 # Dynamically generate a list of jobs to create VMs and add these to
 # our swarm
-VMS := $(shell seq 1 10)
-VM_JOBS := $(addprefix machine,${VMS})
-.aws/machines: ${VM_JOBS}
-${VM_JOBS}: machine%:
+AWS_VMS := $(shell seq 1 10)
+AWS_VM_JOBS := $(addprefix aws-machine,${AWS_VMS})
+.aws/machines: ${AWS_VM_JOBS}
+${AWS_VM_JOBS}: aws-machine%:
 	docker-machine create \
 		-d amazonec2 \
 		--swarm \
 		--amazonec2-instance-type m4.4xlarge \
 		--amazonec2-region us-east-1 \
 		--amazonec2-security-group docker-machine \
+		--amazonec2-spot-price 1.00 \
 		--amazonec2-subnet-id $(shell cat .aws/subnet) \
 		--amazonec2-vpc-id $(shell cat .aws/vpc) \
 		--swarm-discovery token://$(shell cat .aws/swarm) \
-		swarm-$*
+		swarm-aws-$*
 
-.PHONY: clean .aws/machines ${VM_JOBS}
+
+# ------------------------------------------------------
+# docker-machine / swarm tasks for running on GCE
+# Make sure you have gcloud compute tools set up with a default
+# project. When machines are launched your browser will launch
+# asking you to verify the OAuth permissions
+
+gce: .gce/consul # .gce/machines
+	@echo All machines ready. To configure your Docker client run:
+	@echo 'eval "$$(docker-machine env --swarm swarm-master-gce)"'
+
+# initialize the swarm
+.gce/swarm:
+	mkdir -p .gce
+	docker run --rm swarm create > .gce/swarm
+
+# Create the swarm master in your local Virtualbox environment
+.gce/master: .gce/swarm
+	-docker-machine rm swarm-master-gce
+	docker-machine create \
+		-d virtualbox \
+		--swarm \
+		--swarm-master \
+		--swarm-discovery token://$(shell cat .gce/swarm) \
+		swarm-master-gce
+	@touch .gce/master
+
+# Set up and get info about the GCE environment.
+# This sets up a firewall rule that allows communication on ssh, 8092 (CB console),
+# and 8500 (consul) from your current IP.
+.gce/gce: .gce/network
+	gcloud info --format flattened | awk '/config.project/{print $$2}' > .gce/gce
+.gce/network:
+	gcloud compute firewall-rules create remote-access \
+		--allow tcp:22,tcp:8092,tcp:2376,tcp:8500 --network default \
+		--source-ranges $(shell curl http://ifconfig.co)/32
+	@touch .gce/network
+
+# Create the VM where we're going to run consul and register it to swarm.
+# We need to capture the machine's IP so that we can pass this value to
+# docker-compose so CB nodes can find consul.
+.gce/consul: .gce/master .gce/gce
+	docker-machine create \
+		-d google \
+		--swarm \
+		--google-machine-type n1-standard-1 \
+		--google-project $(shell cat .gce/gce) \
+		--swarm-discovery token://$(shell cat .gce/swarm) \
+		swarm-gce-consul
+	docker-machine ip swarm-gce-consul > .gce/consul
+
+# Dynamically generate a list of jobs to create VMs and add these to
+# our swarm
+GCE_VMS := $(shell seq 1 10)
+GCE_VM_JOBS := $(addprefix gce-machine,${GCE_VMS})
+.gce/machines: ${GCE_VM_JOBS}
+${GCE_VM_JOBS}: gce-machine%:
+	docker-machine create \
+		-d google \
+		--swarm \
+		--google-machine-type n1-standard-16 \
+		--google-project $(shell cat .gce/gce) \
+		--swarm-discovery token://$(shell cat .gce/swarm) \
+		swarm-gce-$*
+
+# ------------------------------------------------------
+
+.PHONY: clean .aws/machines .gce/machines ${AWS_VM_JOBS} ${GCE_VM_JOBS}

--- a/test/makefile
+++ b/test/makefile
@@ -36,3 +36,89 @@ build/durability: .build-builder
 ship: build
 	docker push 0x74696d/cbc-benchmark-durable
 	docker push 0x74696d/cbc-benchmark-perf
+
+# ------------------------------------------------------
+# docker-machine / swarm tasks for running on AWS/GCE
+# Make sure your AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment
+# variables have been set.
+# You'll also need the awscli installed: https://aws.amazon.com/cli/
+
+aws: .aws/consul .aws/machines
+	@echo All machines ready. To configure your Docker client run:
+	@echo 'eval "$$(docker-machine env --swarm swarm-master)"'
+
+# initialize the swarm
+.aws/swarm:
+	mkdir -p .aws
+	docker run --rm swarm create > .aws/swarm
+
+# Create the swarm master in your local Virtualbox environment
+.aws/master: .aws/swarm
+	-docker-machine rm swarm-master
+	docker-machine create \
+		-d virtualbox \
+		--swarm \
+		--swarm-master \
+		--swarm-discovery token://$(shell cat .aws/swarm) \
+		swarm-master
+	touch .aws/master
+
+# Set up and get info about the AWS environment.
+# This sets up a security group that allows all communication between the nodes
+# of the cluster but only ssh and 8092 (CB console) access from your current IP.
+.aws/aws: .aws/vpc .aws/subnet .aws/auth-secgroup
+.aws/vpc:
+	aws ec2 describe-vpcs | json -a Vpcs\[0\].VpcId > .aws/vpc
+.aws/subnet:
+	aws ec2 describe-subnets --filters Name=availabilityZone,Values=us-east-1a | json -a Subnets[0].SubnetId > .aws/subnet
+.aws/secgroup:
+	aws ec2 create-security-group --vpc-id $(shell cat .aws/vpc) --group-name docker-machine | json -a GroupName > .aws/secgroup
+.aws/myip:
+	curl http://ifconfig.co > .aws/myip
+.aws/auth-secgroup: .aws/secgroup .aws/myip
+	aws ec2 authorize-security-group-ingress --group-name docker-machine \
+		--protocol tcp --port 0-65535 --source-group $(shell cat .aws/secgroup)
+	aws ec2 authorize-security-group-ingress --group-name docker-machine \
+		--protocol udp --port 0-65535 --source-group $(shell cat .aws/secgroup)
+	aws ec2 authorize-security-group-ingress --group-name docker-machine \
+		--protocol tcp --port 22 --cidr $(shell cat .aws/myip)/32
+	aws ec2 authorize-security-group-ingress --group-name docker-machine \
+		--protocol tcp --port 8092 --cidr $(shell cat .aws/myip)/32
+	aws ec2 authorize-security-group-ingress --group-name docker-machine \
+		--protocol tcp --port 2376 --cidr $(shell cat .aws/myip)/32
+	aws ec2 describe-security-groups --group-names docker-machine > .aws/auth-secgroup
+
+# Create the VM where we're going to run consul and register it to swarm.
+# We need to capture the machine's IP so that we can pass this value to
+# docker-compose so CB nodes can find consul.
+.aws/consul: .aws/master .aws/aws
+	docker-machine create \
+		-d amazonec2 \
+		--swarm \
+		--amazonec2-instance-type t2.micro \
+		--amazonec2-region us-east-1 \
+		--amazonec2-security-group docker-machine \
+		--amazonec2-subnet-id $(shell cat .aws/subnet) \
+		--amazonec2-vpc-id $(shell cat .aws/vpc) \
+		--swarm-discovery token://$(shell cat .aws/swarm) \
+		swarm-consul
+	docker-machine ip swarm-consul > .aws/consul
+
+# Dynamically generate a list of jobs to create VMs and add these to
+# our swarm
+VMS := $(shell seq 1 10)
+VM_JOBS := $(addprefix machine,${VMS})
+.aws/machines: ${VM_JOBS}
+${VM_JOBS}: machine%:
+	docker-machine create \
+		-d amazonec2 \
+		--swarm \
+		--amazonec2-instance-type m4.4xlarge \
+		--amazonec2-region us-east-1 \
+		--amazonec2-security-group docker-machine \
+		--amazonec2-subnet-id $(shell cat .aws/subnet) \
+		--amazonec2-vpc-id $(shell cat .aws/vpc) \
+		--swarm-discovery token://$(shell cat .aws/swarm) \
+		swarm-$*
+
+.PHONY: clean .aws/machines ${VM_JOBS}

--- a/test/makefile
+++ b/test/makefile
@@ -102,7 +102,7 @@ aws: .aws/consul .aws/machines
 		--amazonec2-vpc-id $(shell cat .aws/vpc) \
 		--swarm-discovery token://$(shell cat .aws/swarm) \
 		swarm-aws-consul
-	docker-machine ip swarm-consul > .aws/consul
+	docker-machine ip swarm-aws-consul > .aws/consul
 
 # Dynamically generate a list of jobs to create VMs and add these to
 # our swarm
@@ -113,7 +113,8 @@ ${AWS_VM_JOBS}: aws-machine%:
 	docker-machine create \
 		-d amazonec2 \
 		--swarm \
-		--amazonec2-instance-type m4.4xlarge \
+		--amazonec2-instance-type m2.4xlarge \
+		--amazonec2-ami ami-e3b9fc86 \
 		--amazonec2-region us-east-1 \
 		--amazonec2-security-group docker-machine \
 		--amazonec2-spot-price 1.00 \


### PR DESCRIPTION
@max123 and @misterbisson:
This PR pulls the extra arguments for pillowfight into the environment so we can toggle them for different versions of the client.

It also includes what appears to be a working set of makefile targets to run our cluster under Docker swarm on AWS or GCE.
