### PR TITLE
revisions for `misterbisson/triton-couchbase:enterprise-3.0.3-r2`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ consul:
     - 8302
     - 8400
     - 8500
+    dns:
+       - 127.0.0.1
     restart: always
 
 #
@@ -19,7 +21,7 @@ consul:
 # Scale this tier and each additional container/instance will automatically self-configure as a member of the cluster
 #
 couchbase:
-    image: misterbisson/triton-couchbase
+    image: misterbisson/triton-couchbase:enterprise-3.0.3-r2
     links:
     - consul
     mem_limit: 4096m

--- a/start.bash
+++ b/start.bash
@@ -32,6 +32,12 @@ while [ $COUCHBASERESPONSIVE != 1 ]; do
 done
 echo
 
+CONSUL="$(sdc-listmachines | json -aH -c "'"$PREFIX"_consul_1' == this.name" ips.1):8500"
+echo
+echo 'Consul is now running'
+echo "Dashboard: $CONSUL"
+command -v open >/dev/null 2>&1 && `open http://$CONSUL/ui/`
+
 CBDASHBOARD="$(sdc-listmachines | json -aH -c "'"$PREFIX"_couchbase_1' == this.name" ips.1):8091"
 echo
 echo 'Couchbase cluster running and bootstrapped'


### PR DESCRIPTION
- Specified the image tag, `misterbisson/triton-couchbase:enterprise-3.0.3-r2`
- Let the Consul container use itself as a DNS host
- Open the Consul web dashboard when spinning up the cluster
