### PR TITLE
Networking workarounds for AWS/GCE

### DIFF
--- a/docker-compose-swarm.yml
+++ b/docker-compose-swarm.yml
@@ -2,6 +2,7 @@
 consul:
     image: progrium/consul:latest
     command: -server -bootstrap-expect 1 -ui-dir /ui
+    net: host
     ports:
     - 53
     - 8300
@@ -11,15 +12,19 @@ consul:
     - 8500:8500
     restart: always
 
+# Run the application on AWS/GCE as follows:
+# sed -r "s/consul:<CONSUL_IP>/consul:$(shell cat .aws/consul)/" ../docker-compose-swarm.yml > /tmp/swarm.yml
+# COMPOSE=/tmp/swarm.yml PREFIX=cb4 VERSION=4 ../start.bash
 
 # Manually bootstrap the first instance, then...
 # Scale this tier and each additional container/instance will automatically
 # self-configure as a member of the cluster
 couchbase4:
     image: 0x74696d/triton-couchbase:4.0.0
+    net: host
     extra_hosts:
-    - consul:${CONSUL_IP}
-    mem_limit: 128g
+    - "consul:<CONSUL_IP>"
+    mem_limit: 60g
     ports:
     - 8091:8091
     - 8092:8092
@@ -32,9 +37,10 @@ couchbase4:
 
 couchbase3:
     image: misterbisson/triton-couchbase
+    net: host
     extra_hosts:
-    - consul:${CONSUL_IP}
-    mem_limit: 128g
+    - "consul:<CONSUL_IP>"
+    mem_limit: 60g
     ports:
     - 8091:8091
     - 8092:8092
@@ -48,9 +54,9 @@ couchbase3:
 # Run the pillowfight client built from the durablity_tokens branch
 pillowfight_durable:
     image: 0x74696d/cbc-benchmark-durable
-    mem_limit: 64g
+    mem_limit: 16g
     extra_hosts:
-    - consul:${CONSUL_IP}
+    - "consul:<CONSUL_IP>"
     environment:
     - ITEMS=93750000
     - THREADS=20
@@ -61,9 +67,9 @@ pillowfight_durable:
 # Run the current pillowfight client
 pillowfight_perf:
     image: 0x74696d/cbc-benchmark-perf
-    mem_limit: 64g
+    mem_limit: 16g
     extra_hosts:
-    - consul:${CONSUL_IP}
+    - "consul:<CONSUL_IP>"
     environment:
     - ITEMS=93750000
     - THREADS=20

--- a/start.bash
+++ b/start.bash
@@ -28,7 +28,7 @@ while [ $COUCHBASERESPONSIVE != 1 ]; do
     RUNNING=$(docker inspect ${PREFIX}_couchbase${VERSION}_1 | json -a State.Running)
     if [ "$RUNNING" == "true" ]
     then
-        docker exec -it ${PREFIX}_couchbase${VERSION}_1 triton-bootstrap bootstrap benchmark
+        docker exec ${PREFIX}_couchbase${VERSION}_1 triton-bootstrap bootstrap benchmark
         let COUCHBASERESPONSIVE=1
     else
         sleep 1.3

--- a/test/makefile
+++ b/test/makefile
@@ -54,7 +54,7 @@ aws: .aws/consul .aws/machines
 
 # Create the swarm master in your local Virtualbox environment
 .aws/master: .aws/swarm
-	-docker-machine rm swarm-master-aws
+	-docker-machine rm swarm-aws-master
 	docker-machine create \
 		-d virtualbox \
 		--swarm \
@@ -123,6 +123,15 @@ ${AWS_VM_JOBS}: aws-machine%:
 		--swarm-discovery token://$(shell cat .aws/swarm) \
 		swarm-aws-$*
 
+AWS_HOSTS_JOBS := $(addprefix aws-hosts,${AWS_VMS})
+.aws/hosts: ${AWS_HOSTS_JOBS}
+${AWS_HOSTS_JOBS}: aws-hosts%:
+	docker-machine ssh swarm-aws-$* 'echo $(shell cat .aws/consul) consul | sudo tee --append /etc/hosts'
+
+.aws/couchbase:
+	sed -r "s/consul:<CONSUL_IP>/consul:$(shell cat .aws/consul)/" \
+		../docker-compose-swarm.yml > /tmp/swarm.yml
+	COMPOSE=/tmp/swarm.yml PREFIX=cb4 VERSION=4 ../start.bash
 
 # ------------------------------------------------------
 # docker-machine / swarm tasks for running on GCE

--- a/test/makefile
+++ b/test/makefile
@@ -166,8 +166,11 @@ gce: .gce/consul # .gce/machines
 	gcloud info --format flattened | awk '/config.project/{print $$2}' > .gce/gce
 .gce/network:
 	gcloud compute firewall-rules create remote-access \
-		--allow tcp:22,tcp:8092,tcp:2376,tcp:8500 --network default \
+		--allow tcp:22,tcp:8091,tcp:8092,tcp:2376 --network default \
 		--source-ranges $(shell curl http://ifconfig.co)/32
+	gcloud compute firewall-rules create remote-access \
+		--allow tcp:8500 --network default \
+		--source-ranges 0.0.0.0/0
 	@touch .gce/network
 
 # Create the VM where we're going to run consul and register it to swarm.

--- a/test/makefile
+++ b/test/makefile
@@ -141,7 +141,7 @@ ${AWS_HOSTS_JOBS}: aws-hosts%:
 
 gce: .gce/consul # .gce/machines
 	@echo All machines ready. To configure your Docker client run:
-	@echo 'eval "$$(docker-machine env --swarm swarm-master-gce)"'
+	@echo 'eval "$$(docker-machine env --swarm swarm-gce-master)"'
 
 # initialize the swarm
 .gce/swarm:
@@ -150,13 +150,13 @@ gce: .gce/consul # .gce/machines
 
 # Create the swarm master in your local Virtualbox environment
 .gce/master: .gce/swarm
-	-docker-machine rm swarm-master-gce
+	-docker-machine rm swarm-gce-master
 	docker-machine create \
 		-d virtualbox \
 		--swarm \
 		--swarm-master \
 		--swarm-discovery token://$(shell cat .gce/swarm) \
-		swarm-master-gce
+		swarm-gce-master
 	@touch .gce/master
 
 # Set up and get info about the GCE environment.
@@ -197,6 +197,20 @@ ${GCE_VM_JOBS}: gce-machine%:
 		--swarm-discovery token://$(shell cat .gce/swarm) \
 		swarm-gce-$*
 
+GCE_HOSTS_JOBS := $(addprefix gce-hosts,${GCE_VMS})
+.gce/hosts: ${GCE_HOSTS_JOBS}
+${GCE_HOSTS_JOBS}: gce-hosts%:
+	docker-machine ssh swarm-gce-$* 'echo $(shell cat .gce/consul) consul | sudo tee --append /etc/hosts'
+
+.gce/run-consul:
+	docker-compose -f ../docker-compose-swarm.yml -p cb4 up -d consul
+
+.gce/run-couchbase:
+	sed -r "s/consul:<CONSUL_IP>/consul:$(shell cat .gce/consul)/" \
+		../docker-compose-swarm.yml > /tmp/swarm.yml
+	COMPOSE=/tmp/swarm.yml PREFIX=cb4 VERSION=4 ../start.bash
+
+
 # ------------------------------------------------------
 
-.PHONY: clean .aws/machines .gce/machines ${AWS_VM_JOBS} ${GCE_VM_JOBS}
+.PHONY: clean .aws/machines .gce/machines .do/machines ${AWS_VM_JOBS} ${GCE_VM_JOBS} ${DO_VM_JOBS}

--- a/test/makefile
+++ b/test/makefile
@@ -212,5 +212,58 @@ ${GCE_HOSTS_JOBS}: gce-hosts%:
 
 
 # ------------------------------------------------------
+# docker-machine / swarm tasks for running on DO
+# Make sure you have a DO_TOKEN environment variable set
+
+do: .do/consul .do/machines
+	@echo All machines ready. To configure your Docker client run:
+	@echo 'eval "$$(docker-machine env --swarm swarm-do-master)"'
+
+# initialize the swarm
+.do/swarm:
+	mkdir -p .do
+	docker run --rm swarm create > .do/swarm
+
+# Create the swarm master in your local Virtualbox environment
+.do/master: .do/swarm
+	-docker-machine rm swarm-do-master
+	docker-machine create \
+		-d virtualbox \
+		--swarm \
+		--swarm-master \
+		--swarm-discovery token://$(shell cat .do/swarm) \
+		swarm-do-master
+	@touch .do/master
+
+# Create the VM where we're going to run consul and register it to swarm.
+# We need to capture the machine's IP so that we can pass this value to
+# docker-compose so CB nodes can find consul.
+.do/consul: .do/master
+	docker-machine create \
+		-d digitalocean \
+		--swarm \
+		--digitalocean-access-token ${DO_TOKEN} \
+		--digitalocean-private-networking true \
+		--digitalocean-size 512mb \
+		--swarm-discovery token://$(shell cat .do/swarm) \
+		swarm-do-consul
+	docker-machine ip swarm-do-consul > .do/consul
+
+# Dynamically generate a list of jobs to create VMs and add these to
+# our swarm
+DO_VMS := $(shell seq 1 10)
+DO_VM_JOBS := $(addprefix do-machine,${DO_VMS})
+.do/machines: ${DO_VM_JOBS}
+${DO_VM_JOBS}: do-machine%:
+	docker-machine create \
+		-d digitalocean \
+		--swarm \
+		--digitalocean-access-token ${DO_TOKEN} \
+		--digitalocean-private-networking true \
+		--digitalocean-size 64gb \
+		--swarm-discovery token://$(shell cat .do/swarm) \
+		swarm-do-$*
+
+# ------------------------------------------------------
 
 .PHONY: clean .aws/machines .gce/machines .do/machines ${AWS_VM_JOBS} ${GCE_VM_JOBS} ${DO_VM_JOBS}


### PR DESCRIPTION
@misterbisson @max123 this PR includes changes to the makefile I've been using for orchestration to workaround problems I had with the AWS/GCE setup:
- use the host networking so that the IP the couchbase containers can see (and with which they register to consul) matches the host's IP
- fix the memory size of the nodes to fit within what we can get from AWS & GCE
- inject the consul IP into docker-compose via sed to a temp file rather than by trying (unsuccessfully!) to inject it via environment variables; I misread the docker-compose docs here.
- added a draft (as-yet-untested) digitalocean piece
