### PR TITLE
Update for Couchbase 4.0 GA

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ curl -O https://raw.githubusercontent.com/joyent/sdc-docker/master/tools/sdc-doc
 
 1. [Clone](git@github.com:misterbisson/clustered-couchbase-in-containers.git) or [download](https://github.com/misterbisson/clustered-couchbase-in-containers/archive/master.zip) this repo.
 1. `cd` into the cloned or downloaded directory.
-1. Execute `bash start.bash` to start everything up.
-1. The Couchbase dashboard should automatically open. Sign in with the user/pass printed in the output of `bash start.bash` to see the working, one-node cluster.
+1. Execute `bash start.sh` to start everything up.
+1. The Couchbase dashboard should automatically open. Sign in with the user/pass printed in the output of `bash start.sh` to see the working, one-node cluster.
 1. Scale the cluster using `docker-compose --project-name=ccic scale up couchbase=$n` and watch the node(s) join the cluster in the Couchbase dashboard.
 
 ## Detailed instructions
 
-The [`start.bash` script](https://github.com/misterbisson/clustered-couchbase-in-containers/blob/master/start.bash) automatically does the following:
+The [`start.sh` script](https://github.com/misterbisson/clustered-couchbase-in-containers/blob/master/start.sh) automatically does the following:
 
 ```bash
 docker-compose pull
@@ -41,7 +41,7 @@ The three services include:
 
 Consul is running in it's default configuration as delivered in [Jeff Lindsay's excellent image](https://registry.hub.docker.com/u/progrium/consul/), but Couchbase is wrapped with a [custom start script that enables the magic here](https://github.com/misterbisson/triton-couchbase/blob/master/bin/triton-bootstrap).
 
-Once the first set of containers is running, the `start.bash` script bootstraps the Couchbase container with the following command:
+Once the first set of containers is running, the `start.sh` script bootstraps the Couchbase container with the following command:
 
 ```bash
 docker exec -it ccic_couchbase_1 triton-bootstrap bootstrap benchmark

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ consul:
 # Scale this tier and each additional container/instance will automatically self-configure as a member of the cluster
 #
 couchbase:
-    image: misterbisson/triton-couchbase:enterprise-3.0.3-r4
+    image: misterbisson/triton-couchbase:enterprise-4.0.0-r1
     restart: always
     mem_limit: 4096m
     links:

--- a/start.sh
+++ b/start.sh
@@ -21,10 +21,10 @@ COUCHBASERESPONSIVE=0
 while [ $COUCHBASERESPONSIVE != 1 ]; do
     echo -n '.'
 
-    RUNNING=$(docker inspect "$PREFIX"_couchbase_1 | json -a State.Running)
+    RUNNING=$(docker inspect "${PREFIX}_couchbase_1" | json -a State.Running)
     if [ "$RUNNING" == "true" ]
     then
-        docker exec -it "$PREFIX"_couchbase_1 triton-bootstrap bootstrap benchmark
+        docker exec -it "${PREFIX}_couchbase_1" triton-bootstrap bootstrap benchmark
         let COUCHBASERESPONSIVE=1
     else
         sleep 1.3
@@ -32,25 +32,24 @@ while [ $COUCHBASERESPONSIVE != 1 ]; do
 done
 echo
 
-CONSUL="$(sdc-listmachines | json -aH -c "'"$PREFIX"_consul_1' == this.name" ips.1):8500"
+CONSUL="$(sdc-listmachines | json -aH -c "'${PREFIX}_consul_1' == this.name" ips.1):8500"
 echo
 echo 'Consul is now running'
 echo "Dashboard: $CONSUL"
 command -v open >/dev/null 2>&1 && `open http://$CONSUL/ui/`
 
-CBDASHBOARD="$(sdc-listmachines | json -aH -c "'"$PREFIX"_couchbase_1' == this.name" ips.1):8091"
+CBDASHBOARD="$(sdc-listmachines | json -aH -c "'${PREFIX}_couchbase_1' == this.name" ips.1):8091"
 echo
 echo 'Couchbase cluster running and bootstrapped'
 echo "Dashboard: $CBDASHBOARD"
-echo "username=Administrator"
-echo "password=password"
+echo 'The username and password are printed in earlier messages'
 command -v open >/dev/null 2>&1 && `open http://$CBDASHBOARD/index.html#sec=servers`
 
 echo
 echo 'Scaling Couchbase cluster to three nodes'
-echo "docker-compose --project-name="$PREFIX" scale couchbase=3"
+echo "docker-compose --project-name=$PREFIX scale couchbase=3"
 docker-compose --project-name=$PREFIX scale couchbase=3
 
 echo
 echo "Go ahead, try a lucky 7 node cluster:"
-echo "docker-compose --project-name="$PREFIX" scale couchbase=7"
+echo "docker-compose --project-name=$PREFIX scale couchbase=7"


### PR DESCRIPTION
- Update for Couchbase 4.0 GA
- Rename `start.bash` to `start.sh`, because nobody seems to like `*.bash`
- Clean up quoting in `start.sh`
